### PR TITLE
Fixes to work with current Canvas Data schema, postgres

### DIFF
--- a/canvas_data_utils/canvas_data_auth.py
+++ b/canvas_data_utils/canvas_data_auth.py
@@ -433,9 +433,8 @@ class CanvasData(object):
                     comp_key = DIM_TABLES_WITH_COMPOSITE_KEY.get(schema_table, None)
                     if comp_key and col['name'] in comp_key['keys']:
                         do_primary_key = True
-                        if col['name'] != 'id':
-                            # only one column can have autoincrement
-                            autoincrement = False
+                        # autoincrement not compatible with composite keys
+                        autoincrement = False
 
                     elif col_num == 1 and col['name'] == 'id':
                         do_primary_key = True

--- a/canvas_data_utils/canvas_data_auth.py
+++ b/canvas_data_utils/canvas_data_auth.py
@@ -341,7 +341,6 @@ class CanvasData(object):
             _iter = iter(self.schema['schema'].items())
 
         for key, schema_element in _iter:
-            if key != 'course_ui_canvas_navigation_dim':
                 table_names.append(key)
         return table_names
 

--- a/canvas_data_utils/canvas_data_auth.py
+++ b/canvas_data_utils/canvas_data_auth.py
@@ -100,6 +100,7 @@ DIALECT_MAP = {
     'sqlite': sqlite
     }
 
+csv.field_size_limit(sys.maxsize)
 
 class CanvasData(object):
 

--- a/canvas_data_utils/canvas_data_auth.py
+++ b/canvas_data_utils/canvas_data_auth.py
@@ -418,6 +418,10 @@ class CanvasData(object):
                     comp_key = DIM_TABLES_WITH_COMPOSITE_KEY.get(schema_table, None)
                     if comp_key and col['name'] in comp_key['keys']:
                         do_primary_key = True
+                        if col['name'] != 'id':
+                            # only one column can have autoincrement
+                            autoincrement = False
+
                     elif col_num == 1 and col['name'] == 'id':
                         do_primary_key = True
                         if schema_table == 'requests':

--- a/canvas_data_utils/canvas_data_auth.py
+++ b/canvas_data_utils/canvas_data_auth.py
@@ -252,6 +252,17 @@ class CanvasData(object):
         except KeyError:
             logger.error('Failed to clean up the group_membership_dim schema')
 
+        # 2) remove the foreign key constraint on some user_id columns; some records contain
+        #    references to users that don't seem to exist (anymore?)
+        try:
+            for table_name in ['wiki_page_fact', 'enrollment_dim']:
+                t_cols = schema['schema'][table_name]['columns']
+                for col in t_cols:
+                    if col['name'] == u'user_id':
+                        col.pop('dimension', None)
+        except KeyError:
+            logger.error('Failed to remove the {}.user_id FK constraint'.format(table_name))
+
         return schema
 
     def time_diff(self, last_updated):

--- a/canvas_data_utils/canvas_data_auth.py
+++ b/canvas_data_utils/canvas_data_auth.py
@@ -505,7 +505,7 @@ class CanvasData(object):
         cols = self.table_columns(schema_table)
         for c in cols:
             field_value = getattr(obj, c['name'], None)
-            if field_value == '\N':
+            if field_value == r'\N':
                 setattr(obj, c['name'], None)
             elif c['type'] in ('date', 'datetime', 'timestamp'):
                 if field_value:

--- a/canvas_data_utils/canvas_data_auth.py
+++ b/canvas_data_utils/canvas_data_auth.py
@@ -66,7 +66,7 @@ odd_table_mapping = {
     'conversation_dim': 'conversation',
     'conversation_message_dim': 'conversation_message',
     'conversation_message_participant_fact': 'conversation_message_participant',
-    }
+}
 
 # These tables don't have a field called "id"
 DIM_TABLES_WITHOUT_ID = ('assignment_rule_dim', 'assignment_group_rule_dim', 'conversation_message_participant')
@@ -101,6 +101,7 @@ DIALECT_MAP = {
     }
 
 csv.field_size_limit(sys.maxsize)
+
 
 class CanvasData(object):
 
@@ -343,7 +344,7 @@ class CanvasData(object):
             rows = query.all()
         except Exception as err:
             # Must be a raw ResultProxy
-            logger.exception()
+            logger.exception(err)
             rows = query.fetchall()
 
         output.append(tabulate(rows, headers))
@@ -357,7 +358,7 @@ class CanvasData(object):
             _iter = iter(self.schema['schema'].items())
 
         for key, schema_element in _iter:
-                table_names.append(key)
+            table_names.append(key)
         return table_names
 
     def table_columns(self, schema_table, **kwargs):
@@ -602,12 +603,12 @@ class CanvasData(object):
             logger.debug('{} records successfully imported into {}'.format(len(records), schema_table))
             self.save_imported_files()
         except sqlalchemy.exc.IntegrityError:
-            logger.exception()
+            logger.exception('Failed to load data from %s into %s', csv_filename, schema_table)
 
     def import_data(self, schema_table=None, with_download=True):
         '''downloads and imports all tables unless schema_table is defined, in
         which case it only imports that table'''
-        self.download_all_files()
+        self.download_all_files(table=schema_table)
         self.create_tables()
         for table in self.table_list():
             if not schema_table or table == schema_table:

--- a/canvas_data_utils/canvas_data_auth.py
+++ b/canvas_data_utils/canvas_data_auth.py
@@ -15,7 +15,7 @@ import glob
 
 import sqlalchemy
 from sqlalchemy import create_engine
-from sqlalchemy import Table, Column, Integer, String, MetaData, Boolean, DATE, DATETIME, FLOAT, BigInteger, BIGINT, TIMESTAMP, TEXT, ForeignKey
+from sqlalchemy import Table, Column, Integer, String, MetaData, Boolean, DATE, DateTime, FLOAT, BigInteger, BIGINT, TIMESTAMP, TEXT, ForeignKey
 from sqlalchemy.dialects import postgresql, mysql, sqlite
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.automap import automap_base
@@ -82,13 +82,13 @@ COLUMN_TYPE_MAPPING = {
     'bigint': BIGINT,
     'boolean': Boolean,
     'date': DATE,
-    'datetime': DATETIME,
+    'datetime': DateTime,
     'double precision': FLOAT,
     'int': Integer,
     'integer': Integer,
     'text': TEXT(convert_unicode=True),
     'timestamp': TIMESTAMP,
-    'varchar': String(256, convert_unicode=True),
+    'varchar': String,
     'guid': String(256, convert_unicode=True),
     'enum': String(256, convert_unicode=True)
 }
@@ -410,6 +410,9 @@ class CanvasData(object):
                 for col in self.table_columns(schema_table):
                     col_num += 1
                     col_type = COLUMN_TYPE_MAPPING[col['type']]
+                    if col_type == String and col.get('length'):
+                        col_type = col_type(col['length'], convert_unicode=True)
+
                     column = Column(col['name'], col_type)
 
                     do_primary_key = False

--- a/canvas_data_utils/canvas_data_auth.py
+++ b/canvas_data_utils/canvas_data_auth.py
@@ -460,11 +460,11 @@ class CanvasData(object):
 
     def normalize_values_for_db(self, obj, schema_table):
         '''normalizes some of the data for the database. For example, many fields
-        come across with \N representing a null value. This method changes that to
+        come across with \\N representing a null value. This method changes that to
         `None` so it imports correctly into the database.
 
         This method also ensures that floats are floats, integers are integers,
-        date fields have proper dates or are blank, etc. '''
+        date fields have proper dates or are blank, etc.'''
 
         cols = self.table_columns(schema_table)
         for c in cols:

--- a/tests/test_all_in_one.py
+++ b/tests/test_all_in_one.py
@@ -56,8 +56,8 @@ class TestingCanvasData(TestCase):
         tlist = self.cd.table_list()
         tlist.sort()
         self.assertEqual(base_keys, tlist)
-        self.assertEqual(len(tlist), 56)
-        self.assertEqual(len(base_keys), 56)
+        self.assertEqual(len(tlist), 65)
+        self.assertEqual(len(base_keys), 65)
 
     def test_print_schema(self):
         output = self.cd.print_schema(print_output=False)
@@ -130,7 +130,6 @@ class TestReadConfig(TestCase):
         config, valid, errors = self.cd.config_valid(config_filename)
         self.assertFalse(valid)
         self.assertNotEquals([], errors)
-
 
 def files_with_extension(folder, *extensions):
     files = []


### PR DESCRIPTION
This PR contains a bunch of changes to get the script to work with the current schema and data files:
* handle postgres datetime columns
* handle large field sizes in CSV files (for wiki page content)
* fix errors in the schema JSON: all id columns should be bigints and not varchars; remove some foreign key constraints
* don't skip the `course_ui_canvas_navigation_dim` table
* for string columns, use the length specified in the json schema file instead of hardcoding to 256
* turn off autoincrement for composite-key columns 
* properly handle null (`\N`) values in CSV data
* in `import_data()`, only download the CSV file for the table currently being imported

This should also get tests to pass again.